### PR TITLE
fix: update key exchange header checker according to WiFiClientSecure

### DIFF
--- a/src/gsm_ssl_client.cpp
+++ b/src/gsm_ssl_client.cpp
@@ -15,7 +15,7 @@
 
 #include "GSM_LOG.h"
 
-#ifndef MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED
+#if !defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED) && !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 #  warning "Please configure IDF framework to include mbedTLS -> Enable pre-shared-key ciphersuites and activate at least one cipher"
 #else
 


### PR DESCRIPTION
GSMClientSecure failed on esp32 new firmware version

![image](https://user-images.githubusercontent.com/7764614/172538100-396e3f42-4df3-4dd7-a91b-5e4de0aaa355.png)

I changed the key exchange header checker according to WiFiClientSecure which makes it work again.
https://github.com/espressif/arduino-esp32/blob/99520f66f61d3c88014356ee96e1db89b1931ee4/libraries/WiFiClientSecure/src/ssl_client.cpp#L23-L25